### PR TITLE
Transform Policy API to ListenForPolicyViolations

### DIFF
--- a/pkg/dcgm/api.go
+++ b/pkg/dcgm/api.go
@@ -1,7 +1,9 @@
 package dcgm
 
 import (
+	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"sync"
 	"time"
@@ -103,9 +105,14 @@ func HealthCheckByGpuId(gpuId uint) (DeviceHealth, error) {
 	return healthCheckByGpuId(gpuId)
 }
 
-// Policy sets GPU usage and error policies and notifies in case of any violations via callback functions
-func Policy(gpuId uint, typ ...policyCondition) (<-chan PolicyViolation, error) {
-	return registerPolicy(gpuId, typ...)
+// ListenForPolicyViolations sets GPU usage and error policies and notifies in case of any violations via callback functions
+func ListenForPolicyViolations(ctx context.Context, typ ...policyCondition) (<-chan PolicyViolation, error) {
+	groupId, err := NewDefaultGroup(fmt.Sprintf("policy%d", rand.Uint64()))
+
+	if err != nil {
+		return nil, err
+	}
+	return registerPolicy(ctx, groupId, typ...)
 }
 
 // Introspect returns DCGM hostengine memory and CPU usage

--- a/pkg/dcgm/bcast.go
+++ b/pkg/dcgm/bcast.go
@@ -80,5 +80,8 @@ func (p *publisher) broadcast() {
 }
 
 func (p *publisher) closePublisher() {
+	for _, s := range p.subscriberList() {
+		p.remove(s)
+	}
 	p.close <- true
 }

--- a/pkg/dcgm/policy_test.go
+++ b/pkg/dcgm/policy_test.go
@@ -1,3 +1,6 @@
+//go:build linux && cgo
+// +build linux,cgo
+
 /*
  * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
  *
@@ -17,6 +20,10 @@
 package dcgm
 
 import (
+	"context"
+	"log"
+	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,14 +33,17 @@ import (
 
 func TestPolicyErrors(t *testing.T) {
 	type testCase struct {
-		policy      policyCondition
-		injectError func(gpu uint) error
-		assert      func(cb PolicyViolation)
+		policy      []policyCondition
+		numErrors   int
+		injectError func() error
+		assert      func(cb PolicyViolation, en int)
 	}
 	tests := []testCase{
 		{
-			policy: DbePolicy,
-			injectError: func(gpu uint) error {
+			policy:    []policyCondition{DbePolicy},
+			numErrors: 1,
+			injectError: func() error {
+				gpu := uint(rand.Intn(8) + 1)
 				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_ECC_DBE_VOL_DEV", gpu)
 				return InjectFieldValue(gpu,
 					DCGM_FI_DEV_ECC_DBE_VOL_DEV,
@@ -43,7 +53,7 @@ func TestPolicyErrors(t *testing.T) {
 					int64(1),
 				)
 			},
-			assert: func(cb PolicyViolation) {
+			assert: func(cb PolicyViolation, _ int) {
 				require.NotNil(t, cb)
 				assert.Equal(t, DbePolicy, cb.Condition)
 				require.IsType(t, dbePolicyCondition{}, cb.Data)
@@ -53,8 +63,10 @@ func TestPolicyErrors(t *testing.T) {
 			},
 		},
 		{
-			policy: PowerPolicy,
-			injectError: func(gpu uint) error {
+			policy:    []policyCondition{PowerPolicy},
+			numErrors: 1,
+			injectError: func() error {
+				gpu := uint(rand.Intn(8) + 1)
 				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_POWER_USAGE", gpu)
 				return InjectFieldValue(gpu,
 					DCGM_FI_DEV_POWER_USAGE,
@@ -64,7 +76,7 @@ func TestPolicyErrors(t *testing.T) {
 					float64(300.0),
 				)
 			},
-			assert: func(cb PolicyViolation) {
+			assert: func(cb PolicyViolation, _ int) {
 				require.NotNil(t, cb)
 				assert.Equal(t, PowerPolicy, cb.Condition)
 				require.IsType(t, powerPolicyCondition{}, cb.Data)
@@ -73,8 +85,10 @@ func TestPolicyErrors(t *testing.T) {
 			},
 		},
 		{
-			policy: PCIePolicy,
-			injectError: func(gpu uint) error {
+			policy:    []policyCondition{PCIePolicy},
+			numErrors: 1,
+			injectError: func() error {
+				gpu := uint(rand.Intn(8) + 1)
 				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_POWER_USAGE", gpu)
 				return InjectFieldValue(gpu,
 					DCGM_FI_DEV_PCIE_REPLAY_COUNTER,
@@ -84,7 +98,7 @@ func TestPolicyErrors(t *testing.T) {
 					int64(1),
 				)
 			},
-			assert: func(cb PolicyViolation) {
+			assert: func(cb PolicyViolation, _ int) {
 				require.NotNil(t, cb)
 				assert.Equal(t, PCIePolicy, cb.Condition)
 				require.IsType(t, pciPolicyCondition{}, cb.Data)
@@ -93,8 +107,10 @@ func TestPolicyErrors(t *testing.T) {
 			},
 		},
 		{
-			policy: MaxRtPgPolicy,
-			injectError: func(gpu uint) error {
+			policy:    []policyCondition{MaxRtPgPolicy},
+			numErrors: 1,
+			injectError: func() error {
+				gpu := uint(rand.Intn(8) + 1)
 				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_RETIRED_DBE", gpu)
 				err := InjectFieldValue(gpu,
 					DCGM_FI_DEV_RETIRED_DBE,
@@ -116,7 +132,7 @@ func TestPolicyErrors(t *testing.T) {
 				}
 				return err
 			},
-			assert: func(cb PolicyViolation) {
+			assert: func(cb PolicyViolation, _ int) {
 				require.NotNil(t, cb)
 				assert.Equal(t, MaxRtPgPolicy, cb.Condition)
 				require.IsType(t, retiredPagesPolicyCondition{}, cb.Data)
@@ -125,8 +141,10 @@ func TestPolicyErrors(t *testing.T) {
 			},
 		},
 		{
-			policy: ThermalPolicy,
-			injectError: func(gpu uint) error {
+			policy:    []policyCondition{ThermalPolicy},
+			numErrors: 1,
+			injectError: func() error {
+				gpu := uint(rand.Intn(8) + 1)
 				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_GPU_TEMP", gpu)
 				return InjectFieldValue(gpu,
 					DCGM_FI_DEV_GPU_TEMP,
@@ -136,7 +154,7 @@ func TestPolicyErrors(t *testing.T) {
 					int64(101),
 				)
 			},
-			assert: func(cb PolicyViolation) {
+			assert: func(cb PolicyViolation, _ int) {
 				require.NotNil(t, cb)
 				assert.Equal(t, ThermalPolicy, cb.Condition)
 				require.IsType(t, thermalPolicyCondition{}, cb.Data)
@@ -145,8 +163,10 @@ func TestPolicyErrors(t *testing.T) {
 			},
 		},
 		{
-			policy: NvlinkPolicy,
-			injectError: func(gpu uint) error {
+			policy:    []policyCondition{NvlinkPolicy},
+			numErrors: 1,
+			injectError: func() error {
+				gpu := uint(rand.Intn(8) + 1)
 				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL", gpu)
 				return InjectFieldValue(gpu,
 					DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL,
@@ -156,7 +176,7 @@ func TestPolicyErrors(t *testing.T) {
 					int64(1),
 				)
 			},
-			assert: func(cb PolicyViolation) {
+			assert: func(cb PolicyViolation, _ int) {
 				require.NotNil(t, cb)
 				assert.Equal(t, NvlinkPolicy, cb.Condition)
 				require.IsType(t, nvlinkPolicyCondition{}, cb.Data)
@@ -165,8 +185,10 @@ func TestPolicyErrors(t *testing.T) {
 			},
 		},
 		{
-			policy: XidPolicy,
-			injectError: func(gpu uint) error {
+			policy:    []policyCondition{XidPolicy},
+			numErrors: 1,
+			injectError: func() error {
+				gpu := uint(rand.Intn(8) + 1)
 				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_XID_ERRORS", gpu)
 				return InjectFieldValue(gpu,
 					DCGM_FI_DEV_XID_ERRORS,
@@ -176,7 +198,7 @@ func TestPolicyErrors(t *testing.T) {
 					int64(16),
 				)
 			},
-			assert: func(cb PolicyViolation) {
+			assert: func(cb PolicyViolation, _ int) {
 				require.NotNil(t, cb)
 				assert.Equal(t, XidPolicy, cb.Condition)
 				require.IsType(t, xidPolicyCondition{}, cb.Data)
@@ -184,13 +206,70 @@ func TestPolicyErrors(t *testing.T) {
 				assert.Equal(t, uint(16), xidPolicyCondition.ErrNum)
 			},
 		},
+		{
+			//testcase: register multiple policy conditions
+			policy:    []policyCondition{NvlinkPolicy, XidPolicy},
+			numErrors: 2,
+			injectError: func() error {
+				gpu := uint(rand.Intn(8) + 1)
+				//Inject a DBE error; since it has not registered DBEPolicy it will not get this event.
+				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_ECC_DBE_VOL_DEV", gpu)
+				err := InjectFieldValue(gpu,
+					DCGM_FI_DEV_ECC_DBE_VOL_DEV,
+					DCGM_FT_INT64,
+					0,
+					time.Now().Add(60*time.Second).UnixMicro(),
+					int64(1),
+				)
+				gpu = uint(rand.Intn(8) + 1)
+				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_XID_ERRORS", gpu)
+				err = InjectFieldValue(gpu,
+					DCGM_FI_DEV_XID_ERRORS,
+					DCGM_FT_INT64,
+					0,
+					time.Now().Add(60*time.Second).UnixMicro(),
+					int64(16),
+				)
+				t.Logf("injecting %s for gpuId %d", "DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL", gpu)
+				err = InjectFieldValue(gpu,
+					DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL,
+					DCGM_FT_INT64,
+					0,
+					time.Now().Add(60*time.Second).UnixMicro(),
+					int64(1),
+				)
+				return err
+			},
+			assert: func(cb PolicyViolation, en int) {
+				switch en {
+				case 1:
+					require.NotNil(t, cb)
+					assert.Equal(t, XidPolicy, cb.Condition)
+					require.IsType(t, xidPolicyCondition{}, cb.Data)
+					xidPolicyCondition := cb.Data.(xidPolicyCondition)
+					assert.Equal(t, uint(16), xidPolicyCondition.ErrNum)
+				case 2:
+					require.NotNil(t, cb)
+					assert.Equal(t, NvlinkPolicy, cb.Condition)
+					require.IsType(t, nvlinkPolicyCondition{}, cb.Data)
+					nvlinkPolicyCondition := cb.Data.(nvlinkPolicyCondition)
+					assert.Equal(t, uint(1), nvlinkPolicyCondition.Counter)
+				}
+			},
+		},
 	}
 	for _, tc := range tests {
-		t.Run(string(tc.policy), func(t *testing.T) {
+		t.Run(joinPolicy(tc.policy, "|"), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
 			cleanup, err := Init(Embedded)
 			require.NoError(t, err)
 
-			defer cleanup()
+			defer func() {
+				log.Printf("Cleaning up %s \n", t.Name())
+				cleanup()
+				cancel()
+				time.Sleep(100 * time.Millisecond)
+			}()
 
 			numGPUs, err := GetAllDeviceCount()
 			require.NoError(t, err)
@@ -200,30 +279,47 @@ func TestPolicyErrors(t *testing.T) {
 			}
 
 			entityList := []MigHierarchyInfo{
-				{
-					Entity: GroupEntityPair{EntityGroupId: FE_GPU},
-				},
+				{Entity: GroupEntityPair{EntityGroupId: FE_GPU}},
+				{Entity: GroupEntityPair{EntityGroupId: FE_GPU}},
+				{Entity: GroupEntityPair{EntityGroupId: FE_GPU}},
+				{Entity: GroupEntityPair{EntityGroupId: FE_GPU}},
+				{Entity: GroupEntityPair{EntityGroupId: FE_GPU}},
+				{Entity: GroupEntityPair{EntityGroupId: FE_GPU}},
+				{Entity: GroupEntityPair{EntityGroupId: FE_GPU}},
+				{Entity: GroupEntityPair{EntityGroupId: FE_GPU}},
 			}
 
-			gpuIDs, err := CreateFakeEntities(entityList)
+			_, err = CreateFakeEntities(entityList)
 			require.NoError(t, err)
 
-			gpu := gpuIDs[0]
-
-			callback, err := Policy(gpu, tc.policy)
+			callback, err := ListenForPolicyViolations(ctx, tc.policy...)
 			require.NoError(t, err)
 
-			err = tc.injectError(gpu)
+			err = tc.injectError()
 			require.NoError(t, err)
-
+			numCb := 0
 			select {
 			case callbackData := <-callback:
 				require.NotNil(t, callbackData)
-				tc.assert(callbackData)
-				break
+				numCb++
+				tc.assert(callbackData, numCb)
+				if numCb == tc.numErrors {
+					break
+				}
 			case <-time.After(20 * time.Second):
 				require.Fail(t, "policy callback never happened")
 			}
 		})
 	}
+}
+
+func joinPolicy(policy []policyCondition, sep string) string {
+	var result strings.Builder
+	for i, v := range policy {
+		if i > 0 {
+			result.WriteString(sep)
+		}
+		result.WriteString(string(v))
+	}
+	return result.String()
 }

--- a/tests/dcgm_test.go
+++ b/tests/dcgm_test.go
@@ -98,6 +98,9 @@ func TestDeviceInfo(t *testing.T) {
 		for _, val := range fields {
 			var msg, output string
 			res := Query(id, val)
+			if res == "[N/A]" {
+				continue
+			}
 
 			switch val {
 			case "driver_version":
@@ -180,6 +183,9 @@ func TestDeviceStatus(t *testing.T) {
 		for _, val := range fields {
 			var msg, output string
 			res := Query(id, val)
+			if res == "[N/A]" {
+				continue
+			}
 
 			switch val {
 			case "power.draw":


### PR DESCRIPTION
**Summary of Changes**

This pull request introduces enhancements to the Policy API in the NVIDIA Data Center GPU Manager (DCGM) library. The primary modifications include the deprecation of the existing Policy API and the introduction of the ListenForPolicyViolations API. The new API enables users to set policies for all GPUs collectively, eliminating the need to configure individual GPUs separately. Additionally, the ListenForPolicyViolations API allows users to register and monitor policy violations across all GPUs concurrently, addressing usability constraints and making the API more efficient.

1. Deprecation of Policy API:

> The existing `Policy` API has been deprecated due to usability limitations in managing policies for multiple GPUs individually. 

2. Introduction of ListenForPolicyViolations API:
>  The new API provides a more user-friendly interface for setting policies across all GPUs with a single call, streamlining the configuration process.
>  Policy callbacks can now be registered once during the program's lifetime, simplifying the integration of policy violation monitoring into applications.

**Context and Rationale**

The decision to deprecate the Policy API and introduce ListenForPolicyViolations stems from usability concerns and the recognition that monitoring policy violations for individual GPUs at a time may not be useful in certain scenarios. The changes aim to improve the overall usability and efficiency of policy callback registration with the DCGM library.

**Deprecation Notice**

Developers are advised to migrate from the deprecated Policy API to the new ListenForPolicyViolations API for improved functionality and to ensure compatibility with future releases.
